### PR TITLE
Update pi_cleanup.sh

### DIFF
--- a/pi_cleanup.sh
+++ b/pi_cleanup.sh
@@ -16,14 +16,18 @@ sudo journalctl --vacuum-time=3d
 
 ### 3. Remove unused ConnMan Ethernet profiles
 echo "🌐 Removing old ConnMan Ethernet profiles..."
-ACTIVE_PROFILE=$(connmanctl services 2>/dev/null | grep ethernet | awk '{print $NF}')
-cd /var/lib/connman || exit 1
-for d in ethernet_*_cable; do
-    if [[ "$d" != "$ACTIVE_PROFILE" ]]; then
-        echo "🗑️ Deleting $d"
-        sudo rm -rf "$d"
-    fi
-done
+if [ -d /var/lib/connman ]; then
+    ACTIVE_PROFILE=$(connmanctl services 2>/dev/null | grep ethernet | awk '{print $NF}')
+    cd /var/lib/connman || exit 1
+    for d in ethernet_*_cable; do
+        if [[ "$d" != "$ACTIVE_PROFILE" ]]; then
+            echo "🗑️ Deleting $d"
+            sudo rm -rf "$d"
+        fi
+    done
+else
+    echo "ConnMan directory not found, skipping..."
+fi
 
 ### 4. Clear thumbnail cache (GUI systems)
 echo "🖼️ Clearing thumbnail cache..."


### PR DESCRIPTION
This pull request improves the robustness of the ConnMan Ethernet profile cleanup section in the `pi_cleanup.sh` script. The script now checks for the existence of the `/var/lib/connman` directory before attempting to remove old Ethernet profiles, and provides a clear message if the directory is missing.

Error handling and user feedback improvements:

* Added a check to ensure `/var/lib/connman` exists before running the cleanup loop, preventing errors when the directory is absent.
* Added an informative message ("ConnMan directory not found, skipping...") to notify the user if the cleanup step is skipped due to the missing directory.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added a safeguard to prevent errors if the ConnMan directory does not exist during cleanup.
  * Now displays a message and skips profile removal when the ConnMan directory is missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->